### PR TITLE
Fixes Issue #5 & #10 & #21+ Live Stream Hot Fix

### DIFF
--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -67,7 +67,11 @@ export default function Controls(props: IControlsProps): JSX.Element {
           </Button>
         </Col>
         <Col>
-          <Button block variant="danger" onClick={() => onGames(games + 1)}>
+          <Button
+            block
+            style={{ backgroundColor: "#a62700" }}
+            onClick={() => onGames(games + 1)}
+          >
             Lose
           </Button>
         </Col>
@@ -87,7 +91,7 @@ export default function Controls(props: IControlsProps): JSX.Element {
             as="textarea"
             rows={20}
             style={{
-              backgroundColor: dark ? "gray" : "white",
+              backgroundColor: dark ? "dimgray" : "white",
               color: dark ? "white" : " black",
             }}
           />

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -62,7 +62,12 @@ export default function Controls(props: IControlsProps): JSX.Element {
       </Row>
       <Row className="my-2">
         <Col>
-          <Button block variant="success" onClick={handleWin}>
+          <Button
+            block
+            style={{ backgroundColor: "seagreen" }}
+            variant="success"
+            onClick={handleWin}
+          >
             Win
           </Button>
         </Col>

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -83,7 +83,14 @@ export default function Controls(props: IControlsProps): JSX.Element {
         <Col>
           <h2>notes:</h2>
 
-          <Form.Control as="textarea" rows={20} />
+          <Form.Control
+            as="textarea"
+            rows={20}
+            style={{
+              backgroundColor: dark ? "gray" : "white",
+              color: dark ? "white" : " black",
+            }}
+          />
         </Col>
       </Row>
     </React.Fragment>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header(props: IHeaderProps): JSX.Element {
           <Image src="assets/amongNotes.gif" alt="Notes logo" fluid />
         </Col>
         <Col className="px-1 d-flex justify-content-center align-items-center">
-          <h1 className="h2">
+          <h1 title="Click to edit" className="h2">
             <Form.Control id="title" type="text" defaultValue="fusliez notes" />
           </h1>
         </Col>

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -145,7 +145,7 @@ export default function MainContent(props: IMainContentProps): JSX.Element {
                     <Col className="p-0 pr-1">
                       <Form.Control
                         type="text"
-                        placeholder="Player name"
+                        placeholder="Name"
                         size="sm"
                         className={`my-1 px-3 ${dark ? "dark-input" : ""}`}
                         defaultValue={name}
@@ -153,11 +153,9 @@ export default function MainContent(props: IMainContentProps): JSX.Element {
                           event: React.ChangeEvent<HTMLInputElement>
                         ) => handleChange(section, index, event)}
                         style={{
-                          color: dark ? "white" : "black",
+                          color: "black",
+                          fontSize: "18px",
                           fontWeight: 600,
-                          textShadow: dark
-                            ? "-1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000"
-                            : "-1px -1px 0 #FFF, 1px -1px 0 #FFF, -1px 1px 0 #FFF, 1px 1px 0 #FFF",
                         }}
                       />
                     </Col>

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -116,13 +116,16 @@ export default function MainContent(props: IMainContentProps): JSX.Element {
                 <Row
                   className={`border ${
                     dark ? `border-secondary` : "border-dark"
-                  } rounded ${index % 2 ? "ml-0" : "mr-0"} pl-1`}
+                  } rounded ${index % 2 ? "ml-0" : "mr-0"} ${
+                    names ? "pl-1" : ""
+                  }`}
                   style={{
-                    backgroundColor: name
-                      ? color === "brown"
+                    backgroundColor:
+                      !name || !names
+                        ? "transparent"
+                        : color === "brown"
                         ? "	saddlebrown"
-                        : color
-                      : "transparent",
+                        : color,
                   }}
                 >
                   <Col
@@ -133,7 +136,7 @@ export default function MainContent(props: IMainContentProps): JSX.Element {
                       src={`assets/${color}.png`}
                       alt={color}
                       className={`${names ? "player-img" : ""} ${
-                        name != "" ? "" : "not-active"
+                        name != "" || !names ? "" : "not-active"
                       }`}
                     />
                   </Col>

--- a/src/components/Scores.css
+++ b/src/components/Scores.css
@@ -1,0 +1,7 @@
+.progress-bar-win {
+  background-color: seagreen;
+}
+
+.progress-bar-lose {
+  background-color: #a62700;
+}

--- a/src/components/Scores.tsx
+++ b/src/components/Scores.tsx
@@ -19,7 +19,7 @@ export default function Scores(props: IScoresProps): JSX.Element {
         <Col>
           <ProgressBar className="bg-danger">
             <ProgressBar variant="success" now={rate} />
-            <div id="win-rate" className="h5">
+            <div id="win-rate" className="h5" style={{ color: "white" }}>
               Winning rate: {rate}%
             </div>
           </ProgressBar>

--- a/src/components/Scores.tsx
+++ b/src/components/Scores.tsx
@@ -1,6 +1,7 @@
 import { Col, Form, ProgressBar, Row } from "react-bootstrap";
 
 import React from "react";
+import "./Scores.css";
 
 export interface IScoresProps {
   wins: number;
@@ -11,14 +12,16 @@ export interface IScoresProps {
 
 export default function Scores(props: IScoresProps): JSX.Element {
   const { wins, games, onWins, onGames } = props;
-  const rate = games > 0 ? Math.floor((wins / games) * 100) : 100;
+  // using Math.ceil instead of Math.floor
+  // just to make leslie feel better KEKW
+  const rate = games > 0 ? Math.ceil((wins / games) * 100) : 100;
 
   return (
     <React.Fragment>
       <Row>
         <Col>
-          <ProgressBar className="bg-danger">
-            <ProgressBar variant="success" now={rate} />
+          <ProgressBar className="progress-bar-lose">
+            <ProgressBar className="progress-bar-win" now={rate} />
             <div id="win-rate" className="h5" style={{ color: "white" }}>
               Winning rate: {rate}%
             </div>


### PR DESCRIPTION
Fixes Kedyn/fusliez-notes#5 & Kedyn/fusliez-notes#10 & Kedyn/fusliez-notes#21

- Textarea in dark mode is now having a darker background
- Winning rate text is changed to white regardless of theme
- Win rate progress bar's red changed to a more muted tone #A62700
- Removed padding for player icon & removed opacity if Shows Players Name is false