### PR TITLE
Enable editing/read-only modes for player colours and names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Released]
 
+### [v0.9.2] - 10/07/2020
+
+#### Added
+
+- Added feature to enable read-only/editing mode for player colours and names
+
 ### [v0.9.1] - 10/07/2020
 
 #### Added

--- a/src/assets/locales/en-US/translation.json
+++ b/src/assets/locales/en-US/translation.json
@@ -24,7 +24,9 @@
     "resetRound": "Reset Round",
     "resetAll": "Reset All",
     "notes": "Notepad",
-    "resetNotes": "Reset Notepad"
+    "resetNotes": "Reset Notepad",
+    "lockPlayers": "Lock Players",
+    "unlockPlayers": "Unlock Players"
   },
   "maps": {
     "title": "Maps",

--- a/src/assets/locales/es-MX/translation.json
+++ b/src/assets/locales/es-MX/translation.json
@@ -24,7 +24,9 @@
     "resetRound": "Reiniciar Ronda",
     "resetAll": "Reiniciar Todo",
     "notes": "Notas",
-    "resetNotes": "Reiniciar Notas"
+    "resetNotes": "Reiniciar Notas",
+    "lockPlayers": "Lock Players",
+    "unlockPlayers": "Unlock Players"
   },
   "maps": {
     "title": "Maps",

--- a/src/assets/locales/pt-BR/translation.json
+++ b/src/assets/locales/pt-BR/translation.json
@@ -24,7 +24,9 @@
     "resetRound": "Reiniciar Rodada",
     "resetAll": "Reiniciar Tudo",
     "notes": "Notas",
-    "resetNotes": "Reiniciar Notas"
+    "resetNotes": "Reiniciar Notas",
+    "lockPlayers": "Lock Players",
+    "unlockPlayers": "Unlock Players"
   },
   "maps": {
     "title": "Maps",

--- a/src/assets/locales/ru-RU/translation.json
+++ b/src/assets/locales/ru-RU/translation.json
@@ -24,7 +24,9 @@
     "resetRound": "Сбросить раунд",
     "resetAll": "Сбросить все",
     "notes": "Записки",
-    "resetNotes": "Сбросить записки"
+    "resetNotes": "Сбросить записки",
+    "lockPlayers": "Lock Players",
+    "unlockPlayers": "Unlock Players"
   },
   "maps": {
     "title": "Maps",

--- a/src/components/MainContent/MainContent.styles.ts
+++ b/src/components/MainContent/MainContent.styles.ts
@@ -6,6 +6,5 @@ export default createUseStyles({
     padding: props.isMobile ? 0 : "1rem",
     maxWidth: props.isMobile ? "none" : "22.5rem",
     height: "100%",
-    position: "relative",
   }),
 });

--- a/src/components/MainContent/MainContent.styles.ts
+++ b/src/components/MainContent/MainContent.styles.ts
@@ -6,5 +6,6 @@ export default createUseStyles({
     padding: props.isMobile ? 0 : "1rem",
     maxWidth: props.isMobile ? "none" : "22.5rem",
     height: "100%",
+    position: "relative",
   }),
 });

--- a/src/components/Player/Player.styles.ts
+++ b/src/components/Player/Player.styles.ts
@@ -29,6 +29,7 @@ export default createUseStyles((theme: ITheme) => ({
     transition: "border-color 0.2s ease",
     "&:hover": {
       borderColor: `rgba(${hexToRGB(theme.textColorAlt)}, 0.25)`,
+      cursor: props.isReadOnly ? "grab" : "pointer",
     },
   }),
   PlayerIcon: (props) => ({

--- a/src/components/Player/Player.styles.ts
+++ b/src/components/Player/Player.styles.ts
@@ -47,7 +47,7 @@ export default createUseStyles((theme: ITheme) => ({
     backgroundSize: "1.75rem auto",
     backgroundPosition: "center 0.25rem",
     "&:hover": {
-      cursor: props.isReadOnly ? "grab" : "pointer",
+      cursor: props.isReadOnly ? "grab" : props.showNames ? "pointer" : "grab",
     },
   }),
   PlayerName: {

--- a/src/components/Player/Player.styles.ts
+++ b/src/components/Player/Player.styles.ts
@@ -47,7 +47,7 @@ export default createUseStyles((theme: ITheme) => ({
     backgroundSize: "1.75rem auto",
     backgroundPosition: "center 0.25rem",
     "&:hover": {
-      cursor: props.showNames ? "pointer" : "grab",
+      cursor: props.isReadOnly ? "grab" : "pointer",
     },
   }),
   PlayerName: {
@@ -71,6 +71,10 @@ export default createUseStyles((theme: ITheme) => ({
     "&::placeholder": {
       color: theme.textColor,
       opacity: 0.5,
+    },
+
+    "&[readonly]": {
+      cursor: props.isReadOnly ? "grab" : "text",
     },
   }),
 }));

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -14,6 +14,7 @@ export interface IPlayerProps {
   list: Array<IPlayer>;
   setList: (value: IPlayer[]) => void;
   index: number;
+  isReadOnly: boolean;
 }
 
 export default function Player(props: IPlayerProps): JSX.Element {
@@ -34,7 +35,7 @@ export default function Player(props: IPlayerProps): JSX.Element {
     ...props,
   });
 
-  const { id, color, playerName, list, setList, index } = props;
+  const { id, color, playerName, list, setList, index, isReadOnly } = props;
 
   const handleChange = (
     player: number,
@@ -99,7 +100,7 @@ export default function Player(props: IPlayerProps): JSX.Element {
       {...longPressEvents}
     >
       <div className={classes.PlayerTile}>
-        {isMenuShowing && !isMobile && (
+        {isMenuShowing && !isMobile && !isReadOnly && (
           <ColorsMenu
             isMenuShowing={isMenuShowing}
             setIsMenuShowing={setIsMenuShowing}
@@ -109,6 +110,10 @@ export default function Player(props: IPlayerProps): JSX.Element {
         <div
           className={cx(classes.PlayerIcon, "player-handle")}
           onClick={() => {
+            if (isReadOnly) {
+              return;
+            }
+
             if (showNames && !isMobile) {
               setIsMenuShowing(!isMenuShowing);
             }
@@ -129,6 +134,7 @@ export default function Player(props: IPlayerProps): JSX.Element {
               onKeyPress={handleKeyPress}
               value={playerName}
               ref={htmlElRef}
+              readOnly={isReadOnly}
             />
           </div>
         )}

--- a/src/components/PlayerSection/PlayerSection.tsx
+++ b/src/components/PlayerSection/PlayerSection.tsx
@@ -3,6 +3,7 @@ import Player from "components/Player";
 import React from "react";
 import { ReactSortable } from "react-sortablejs";
 import { useSettings } from "context/SettingsContextProvider";
+import { useLocking } from "context/LockingContextProvider";
 import useStyles from "./PlayerSection.styles";
 
 export interface IPlayerSectionProps {
@@ -14,6 +15,7 @@ export interface IPlayerSectionProps {
 
 export default function PlayerSection(props: IPlayerSectionProps): JSX.Element {
   const { showNames } = useSettings()!; // eslint-disable-line
+  const { isLocked } = useLocking()!;
 
   const classes = useStyles({ showNames });
 
@@ -48,6 +50,7 @@ export default function PlayerSection(props: IPlayerSectionProps): JSX.Element {
               list={list}
               setList={setList}
               index={index}
+              isReadOnly={isLocked}
             />
           ))}
         </ReactSortable>

--- a/src/components/PlayersPanel/PlayersPanel.styles.ts
+++ b/src/components/PlayersPanel/PlayersPanel.styles.ts
@@ -7,4 +7,10 @@ export default createUseStyles({
   PlayersPanelReset: {
     marginTop: "1rem",
   },
+  PlayersPanelLock: {
+    marginRight: "1rem",
+    position: "absolute",
+    right: 0,
+    bottom: 0,
+  },
 });

--- a/src/components/PlayersPanel/PlayersPanel.styles.ts
+++ b/src/components/PlayersPanel/PlayersPanel.styles.ts
@@ -4,13 +4,12 @@ export default createUseStyles({
   PlayersPanel: {
     marginBottom: "1rem",
   },
-  PlayersPanelReset: {
-    marginTop: "1rem",
+  PlayersControls: {
+    display: "flex",
   },
-  PlayersPanelLock: {
-    marginRight: "1rem",
-    position: "absolute",
-    right: 0,
-    bottom: 0,
+  PlayersControlsButtons: {
+    marginTop: "1rem",
+    margin: "0.25rem",
+    width: "-webkit-fill-available",
   },
 });

--- a/src/components/PlayersPanel/PlayersPanel.tsx
+++ b/src/components/PlayersPanel/PlayersPanel.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import PlayerSection from "components/PlayerSection";
 import { useMobile } from "context/MobileContextProvider";
 import { usePlayers } from "context/PlayersContextProvider";
+import { useLocking } from "context/LockingContextProvider";
 import useStyles from "./PlayersPanel.styles";
 import { useTranslation } from "react-i18next";
 import Button from "components/common/Button";
@@ -24,6 +25,12 @@ export default function PlayersPanel(): JSX.Element {
 
     resetPlayersPositions,
   } = usePlayers()!; // eslint-disable-line
+
+  const {
+    isLocked,
+
+    toggleLock,
+  } = useLocking()!;
 
   const { isMobile } = useMobile()!; // eslint-disable-line
 
@@ -74,6 +81,10 @@ export default function PlayersPanel(): JSX.Element {
           isMobile={isMobile}
         />
       ))}
+
+      <Button className={classes.PlayersPanelLock} onClick={() => toggleLock()}>
+        {isLocked ? t("controls.unlockPlayers") : t("controls.lockPlayers")}
+      </Button>
 
       {isMobile && (
         <Button

--- a/src/components/PlayersPanel/PlayersPanel.tsx
+++ b/src/components/PlayersPanel/PlayersPanel.tsx
@@ -82,18 +82,23 @@ export default function PlayersPanel(): JSX.Element {
         />
       ))}
 
-      <Button className={classes.PlayersPanelLock} onClick={() => toggleLock()}>
-        {isLocked ? t("controls.unlockPlayers") : t("controls.lockPlayers")}
-      </Button>
-
-      {isMobile && (
+      <div className={classes.PlayersControls}>
         <Button
-          className={classes.PlayersPanelReset}
-          onClick={() => resetPlayersPositions()}
+          className={classes.PlayersControlsButtons}
+          onClick={() => toggleLock()}
         >
-          Reset Positions
+          {isLocked ? t("controls.unlockPlayers") : t("controls.lockPlayers")}
         </Button>
-      )}
+
+        {isMobile && (
+          <Button
+            className={classes.PlayersControlsButtons}
+            onClick={() => resetPlayersPositions()}
+          >
+            Reset Positions
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/ScoreControls/ScoreControls.tsx
+++ b/src/components/ScoreControls/ScoreControls.tsx
@@ -8,10 +8,12 @@ import { useScores } from "context/ScoresContextProvider";
 import useStyles from "./ScoreControls.styles";
 import { useTheme } from "react-jss";
 import { useTranslation } from "react-i18next";
+import { useLocking } from "context/LockingContextProvider";
 
 export default function ScoreControls(): JSX.Element {
   const { t } = useTranslation();
   const theme = useTheme<ITheme>();
+  const { resetLock } = useLocking()!;
   const {
     crewmateWins,
     crewmateLosses,
@@ -32,8 +34,8 @@ export default function ScoreControls(): JSX.Element {
 
   const resetAll = () => {
     resetScores();
-
     resetPlayers();
+    resetLock();
   };
 
   return (

--- a/src/context/LockingContextProvider.tsx
+++ b/src/context/LockingContextProvider.tsx
@@ -1,0 +1,40 @@
+import { ILockingContextProvider } from "utils/types";
+
+import React from "react";
+
+const LockingContext: React.Context<
+  ILockingContextProvider | undefined
+> = React.createContext<ILockingContextProvider | undefined>(undefined);
+
+export interface ILockingContextProviderProps {
+  children?: React.ReactNode;
+}
+
+export default function LockingContextProvider(
+  props: ILockingContextProviderProps
+): JSX.Element {
+  const [isLocked, setLock] = React.useState<boolean>(false);
+
+  const resetLock = () => {
+    setLock(false);
+  };
+
+  const toggleLock = () => {
+    setLock(!isLocked);
+  };
+
+  return (
+    <LockingContext.Provider
+      value={{
+        isLocked,
+        toggleLock,
+        resetLock,
+      }}
+    >
+      {props.children}
+    </LockingContext.Provider>
+  );
+}
+
+export const useLocking = (): ILockingContextProvider | undefined =>
+  React.useContext(LockingContext);

--- a/src/context/index.tsx
+++ b/src/context/index.tsx
@@ -3,6 +3,7 @@ import { JssProvider, ThemeProvider } from "react-jss";
 import { DEFAULT_THEME_DATA } from "utils/constants";
 import MobileContextProvider from "./MobileContextProvider";
 import PlayersContextProvider from "./PlayersContextProvider";
+import LockingContextProvider from "./LockingContextProvider";
 import React from "react";
 import ScoresContextProvider from "./ScoresContextProvider";
 import SettingsContextProvider from "./SettingsContextProvider";
@@ -21,7 +22,11 @@ export default function ContextWrapper(
         <ThemeProvider theme={DEFAULT_THEME_DATA}>
           <MobileContextProvider>
             <ScoresContextProvider>
-              <PlayersContextProvider>{props.children}</PlayersContextProvider>
+              <LockingContextProvider>
+                <PlayersContextProvider>
+                  {props.children}
+                </PlayersContextProvider>
+              </LockingContextProvider>
             </ScoresContextProvider>
           </MobileContextProvider>
         </ThemeProvider>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -136,3 +136,10 @@ export interface IPlayersContext {
   resetPlayersPositions: () => void;
   resetPlayers: () => void;
 }
+
+export interface ILockingContextProvider {
+  isLocked: boolean;
+
+  resetLock: () => void;
+  toggleLock: () => void;
+}


### PR DESCRIPTION
Added feature to enable editing/read-only modes for player colours and names as per #19 

I opted to use a button with text to toggle between the modes, but don't know what they're meant to be in the other languages - I didn't want to use Google Translate in case it was severely incorrect.