### PR TITLE
rewrote the Switch component. no longer uses text

### DIFF
--- a/src/components/common/Switch/Switch.styles.ts
+++ b/src/components/common/Switch/Switch.styles.ts
@@ -1,58 +1,72 @@
 import { ITheme } from "utils/types";
 import { createUseStyles } from "react-jss";
 
+const SwitchHeight = 2; // height in rem
+const SwitchWidth = 3.75; // width in rem
+const SwitchGap = 0.125; // percent of height that is not knob
+
 export default createUseStyles((theme: ITheme) => ({
   Switch: {
     display: "flex",
     margin: "0.5rem 0",
     alignItems: "center",
+    justifyContent: "space-between",
   },
-  SwitchControl: {
-    appearance: "none",
-    width: "4rem",
-    height: "2rem",
-    lineHeight: "1.75rem",
+  SwitchLabel: {
     display: "inline-block",
-    position: "relative",
-    borderRadius: "2rem",
+    padding: "0.5rem 0",
+  },
+  SwitchButton: {
+    appearance: "none",
+    backgroundColor: theme.borderColor,
+    borderRadius: `${SwitchHeight / 2}rem/50%`,
+    border: "none",
+    width: `${SwitchWidth}rem`,
+    height: `${SwitchHeight}rem`,
+    display: "inline-block",
     overflow: "hidden",
     outline: "none",
-    border: "none",
+    position: "relative",
     cursor: "pointer",
-    backgroundColor: theme.borderColor,
     transition: "background-color ease 0.2s",
+    marginLeft: "1rem",
     marginRight: "1rem",
     boxShadow: "inset 1px 1px 1px rgba(0,0,0,0.25)",
-
-    "&:before": {
-      content: '"on off"',
-      display: "block",
+    "&::before": {
       position: "absolute",
-      zIndex: "2",
-      left: 0,
-      width: "1.75rem",
-      height: "1.75rem",
-      background: theme.textColorSecondary,
+      content: '""',
+      display: "block",
+      height: "0.5rem",
+      left: "0.6rem",
+      top: "0.7rem",
+      width: "1rem",
+      transform: "rotate(-45deg)",
+      borderLeft: `0.25rem solid ${theme.textColorPrimary}`,
+      borderBottom: `0.25rem solid ${theme.textColorPrimary}`,
+      opacity: 0,
+      transition: "opacity 0.3s",
+    },
+    "&::after": {
+      position: "absolute",
+      content: '""',
+      display: "block",
+      top: `${SwitchHeight * SwitchGap}rem`,
+      left: `${SwitchHeight * SwitchGap}rem`,
+      bottom: `${SwitchHeight * SwitchGap}rem`,
+      height: `${SwitchHeight - 2 * (SwitchHeight * SwitchGap)}rem`,
+      width: `${SwitchHeight - 2 * (SwitchHeight * SwitchGap)}rem`,
       borderRadius: "50%",
-      textTransform: "uppercase",
-      textIndent: "-1.6rem",
-      wordSpacing: "2.4rem",
-      color: theme.textColorSecondary,
-      fontSize: "0.75rem",
-      margin: "0.125rem 0",
-      whiteSpace: "nowrap",
-      boxShadow: "1px 1px 1px rgba(0,0,0,0.25)",
+      background: theme.textColorSecondary,
       transition: "all cubic-bezier(0.3, 1.5, 0.7, 1) 0.3s",
     },
     "&:checked": {
       backgroundColor: theme.activeColor,
     },
-    "&:checked:before": {
-      left: "2rem",
+    "&:checked::before": {
+      opacity: 1,
     },
-  },
-  SwitchLabel: {
-    display: "inline-block",
-    padding: "0.5rem 0",
+    "&:checked::after": {
+      left: `calc(100% - ${SwitchHeight - SwitchHeight * SwitchGap}rem)`,
+    },
   },
 }));

--- a/src/components/common/Switch/Switch.tsx
+++ b/src/components/common/Switch/Switch.tsx
@@ -12,13 +12,9 @@ export default function Switch(props: ISwitchProps): JSX.Element {
   const { label, ...other } = props;
 
   return (
-    <div>
-      <label className={classes.Switch}>
-        <input className={classes.SwitchControl} type="checkbox" {...other} />
-        <span className={classes.SwitchLabel}>{label}</span>
-      </label>
+    <div className={classes.Switch}>
+      <label className={classes.SwitchLabel}>{label}</label>
+      <input className={classes.SwitchButton} type="checkbox" {...other} />
     </div>
   );
 }
-
-//the previous was created by using the https://danklammer.com/articles/simple-css-toggle-switch/ styles


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1987274/98197577-4a213880-1ee4-11eb-85cc-ee359fa4ccb1.png)

After:
![image](https://user-images.githubusercontent.com/1987274/98197607-56a59100-1ee4-11eb-9a5c-257e2dc24a77.png)

there's some arithmetic to calculate the sizes based on variables. ideally i'd have done that for the checkmark too, but at this point it seemed ridiculous
