### PR TITLE
Vertical notepad resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 docs/
 node_modules/
 .eslintcache
+.idea/

--- a/src/components/NotesPanel/NotesPanel.styles.ts
+++ b/src/components/NotesPanel/NotesPanel.styles.ts
@@ -28,5 +28,6 @@ export default createUseStyles({
     flex: "1 0 auto",
     marginBottom: "1rem",
     fontSize: "1.25rem",
+    resize: "vertical",
   },
 });


### PR DESCRIPTION
Added block for horizontal textarea resize, allow only vertical resize.

Screenshot of the problem:
![image](https://user-images.githubusercontent.com/5169399/98543555-f53e4300-2292-11eb-8c78-6e55c501f335.png)
