### PR TITLE
Fix boolean settings problem

### DIFF
--- a/src/store/slices/SettingsSlice.ts
+++ b/src/store/slices/SettingsSlice.ts
@@ -13,9 +13,9 @@ function getInitialSate(): ISettings {
     const settingsObject = JSON.parse(localSettingsData);
 
     return {
-      showNames: settingsObject.showNames || DEFAULT_SETTINGS.showNames,
+      showNames: settingsObject.showNames ?? DEFAULT_SETTINGS.showNames,
       isColorBlind:
-        settingsObject.isColorBlind || DEFAULT_SETTINGS.isColorBlind,
+        settingsObject.isColorBlind ?? DEFAULT_SETTINGS.isColorBlind,
     };
   }
 


### PR DESCRIPTION
`DEFAULT_SETTINGS.showNames` is always true, so saving any settings for this has no effect and it turns out to be true after refreshing the page.