### PR TITLE
fix the google fonts link in the head tag

### DIFF
--- a/src/templates/index.template.html
+++ b/src/templates/index.template.html
@@ -51,8 +51,8 @@
     <meta name="application-name" content="fusliez notes" />
     <meta name="theme-color" content="#282b2f" />
 
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      rel="preconnect"
       href="https://fonts.googleapis.com/css?family=Inter:wght@200,400;500;600&display=swap"
       rel="stylesheet"
     />


### PR DESCRIPTION
for whatever reason the google fonts link wasn't set correctly and not actually loaded as a stylesheet, thus the Inter font was broken.

this should fix that